### PR TITLE
Add kanjimap to projects section

### DIFF
--- a/site/index.js
+++ b/site/index.js
@@ -230,6 +230,11 @@ const projects = [
       name: 'Kanji Sensei',
       slug: 'a kanji writing practice tool'
     },
+    {
+      href: 'https://www.kanjimap.eu',
+      name: 'kanjimap',
+      slug: 'every kanji and common words with animated stroke order, readings, compounds, and radical browsing'
+    },
 ]
 
 const About = {


### PR DESCRIPTION
Adds www.kanjimap.eu to the projects section. It's a static reference site for every kanji from KanjiAPI with animated stroke order, readings, compounds, and radical browsing.